### PR TITLE
Adds syntax files for Vim in proper format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Repository for text editor syntax highlighting.
 
 
-## Tamarin prover syntax for Vim
+## Syntax for Vim
 
 Although this repo contains syntax files for other editors it should work with 
 plugin-managers such as Vundle and Pathogen. Just add this line to the 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 These are the syntax files from the [Tamarin prover manual][tamarin-manual].
 
-[tamarin-manual]: (https://tamarin-prover.github.io/manual/book/002_installation.html).
+[tamarin-manual]: https://tamarin-prover.github.io/manual/book/002_installation.html

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# tamarin.vim
+Tamarin prover syntax for Vim

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# tamarin.vim
-Tamarin prover syntax for Vim
+# Tamarin prover syntax for Vim
+
+These are the syntax files from the [Tamarin prover manual][tamarin-manual].
+
+[tamarin-manual]: (https://tamarin-prover.github.io/manual/book/002_installation.html).

--- a/filetype.vim
+++ b/filetype.vim
@@ -1,0 +1,5 @@
+" autocommand to detect .spthy and .sapic files
+augroup filetypedetect
+au BufNewFile,BufRead *.spthy	setf spthy
+au BufNewFile,BufRead *.sapic	setf sapic
+augroup END

--- a/syntax/sapic.vim
+++ b/syntax/sapic.vim
@@ -1,0 +1,217 @@
+" Vim syntax file
+" Language:     SAPIC format for Applied Pi calculus-style embedding in tamarin
+" Maintainer: Robert Künnemann <robert.kuennemann@uni-saarland.de>
+" Last Change:  2017 Feb 28
+" based on Claudio Fleiner's <claudio@fleiner.com> spthy syntax highlighting
+" file.
+
+" Quit when a syntax file was already loaded
+if !exists("main_syntax")
+  if version < 600
+    syntax clear
+  elseif exists("b:current_syntax")
+    finish
+  endif
+  " we define it here so that included files can test for it
+  let main_syntax='sapic'
+  syn region sapicFold start="{" end="}" transparent fold
+endif
+
+" don't use standard HiLink, it will not work with included syntax files
+if version < 508
+  command! -nargs=+ SpthyHiLink hi link <args>
+else
+  command! -nargs=+ SpthyHiLink hi def link <args>
+endif
+
+" some characters that cannot be in a sapic program (outside a string)
+" syn match sapicError "[\\@`]"
+" syn match sapicError "<<<\|\.\.\|=>\|<>\|||=\|&&=\|[^-]->\|\*\/"
+" syn match sapicOK "\.\.\."
+
+syn match sapicLAtom	        ":>"
+syn match sapicLAtom	        "--|"
+syn match sapicLAtom	        "<:"
+syn match sapicLAtom	        ">+>"
+syn match sapicLAtom	        ">->"
+syn match sapicLAtom	        "="
+syn match sapicLAtom	        "@"
+syn match sapicLAtom	        "<"
+
+
+syn keyword sapicConstr         aenc sdec senc sdec sign verify hashing signing
+syn match sapicConstr           "\<h("he=e-1
+syn match sapicConstr           "\<sk("he=e-1
+syn match sapicConstr           "\<pk("he=e-1
+syn match sapicConstr           "\<fr("he=e-1
+syn match sapicConstr           "\<pb("he=e-1
+syn match sapicConstr           "\<lts("he=e-1
+syn match sapicConstr           "*"
+syn match sapicConstr           "\^"
+syn match sapicConstr           "\<diffie-hellman"
+syn match sapicConstr           "\<symmetric-encryption"
+syn match sapicConstr           "\<asymmetric-encryption"
+syn match sapicConstr           "\<multiset"
+
+syn keyword sapicDecl           axiom lemma equations functions builtins protocol property in let theory begin end subsection section text predicates options
+syn match sapicDecl             "\<exists-trace"
+syn match sapicDecl             "\<all-traces"
+syn match sapicDecl             "\<enable"
+syn match sapicDecl             "\<rule"
+syn match sapicDecl             "\<assertions"
+syn match sapicDecl             "\<modulo"
+syn match sapicDecl             "\<default_rules"
+syn match sapicDecl             "\<anb-proto"
+syn match sapicDecl             ":"
+syn match sapicDecl             "{\*"
+syn match sapicDecl             "\*}"
+syn match sapicDecl             "\""
+syn match sapicDecl             "\d\+\."
+
+syn match sapicTransfer         "->"
+syn match sapicTransfer         "<-"
+syn match sapicDecl             "-->"
+syn match sapicDecl             "--\["
+syn match sapicDecl             "\]->"
+
+syn keyword sapicTransfer       new in out lookup as in else if lock unlock event insert delete then
+syn match sapicTransfer         "||"
+syn match sapicTransfer         "!"
+
+syn region sapicLiteral          start="'" end="'"
+
+syn match sapicLogicOp          "==>"
+syn match sapicLogicOp          "<=>"
+syn keyword sapicLogicOp        F T All Ex
+syn match sapicLogicOp          "|"
+syn match sapicLogicOp          "&"
+syn match sapicLogicOp          "@"
+syn match sapicLogicOp          "\."
+
+
+
+
+" The following cluster contains all sapic groups except the contained ones
+syn cluster sapicTop add=sapicLAtom,sapicDecl
+
+
+" Comments
+syn keyword sapicTodo		 contained TODO FIXME XXX
+syn region  sapicComment		 start="/\*"  end="\*/" contains=sapicTodo
+syn match   sapicLineComment      "//.*" contains=sapicTodo
+
+syn cluster sapicTop add=sapicComment,sapicLineComment
+
+" Strings and constants
+" syn match   sapicSpecialError     contained "\\."
+" syn match   sapicSpecialCharError contained "[^']"
+" syn match   sapicSpecialChar      contained "\\\([4-9]\d\|[0-3]\d\d\|[\"\\'ntbrf]\|u\+\x\{4\}\)"
+" syn region  sapicString		start=+"+ end=+"+ end=+$+ contains=sapicSpecialChar,sapicSpecialError,@Spell
+" " next line disabled, it can cause a crash for a long line
+" "syn match   sapicStringError	  +"\([^"\\]\|\\.\)*$+
+" syn match   sapicCharacter	 "'[^']*'" contains=sapicSpecialChar,sapicSpecialCharError
+" syn match   sapicCharacter	 "'\\''" contains=sapicSpecialChar
+" syn match   sapicCharacter	 "'[^\\]'"
+" syn match   sapicNumber		 "\<\(0[0-7]*\|0[xX]\x\+\|\d\+\)[lL]\=\>"
+" syn match   sapicNumber		 "\(\<\d\+\.\d*\|\.\d\+\)\([eE][-+]\=\d\+\)\=[fFdD]\="
+" syn match   sapicNumber		 "\<\d\+[eE][-+]\=\d\+[fFdD]\=\>"
+" syn match   sapicNumber		 "\<\d\+\([eE][-+]\=\d\+\)\=[fFdD]\>"
+"
+" " unicode characters
+" syn match   sapicSpecial "\\u\+\d\{4\}"
+"
+" syn cluster sapicTop add=sapicString,sapicCharacter,sapicNumber,sapicSpecial,sapicStringError
+
+" catch errors caused by wrong parenthesis
+" syn region  sapicParenT  transparent matchgroup=sapicParen  start="("  end=")" contains=@sapicTop,sapicParenT1
+" syn region  sapicParenT1 transparent matchgroup=sapicParen1 start="(" end=")" contains=@sapicTop,sapicParenT2 contained
+" syn region  sapicParenT2 transparent matchgroup=sapicParen2 start="(" end=")" contains=@sapicTop,sapicParenT  contained
+" syn match   sapicParenError       ")"
+" " catch errors caused by wrong square parenthesis
+" syn region  sapicParenT  transparent matchgroup=sapicParen  start="\["  end="\]" contains=@sapicTop,sapicParenT1
+" syn region  sapicParenT1 transparent matchgroup=sapicParen1 start="\[" end="\]" contains=@sapicTop,sapicParenT2 contained
+" syn region  sapicParenT2 transparent matchgroup=sapicParen2 start="\[" end="\]" contains=@sapicTop,sapicParenT  contained
+" syn match   sapicParenError       "\]"
+"
+" SpthyHiLink sapicParenError       sapicError
+
+if !exists("sapic_minlines")
+  let sapic_minlines = 10
+endif
+exec "syn sync ccomment sapicComment minlines=" . sapic_minlines
+
+" The default highlighting.
+if version >= 508 || !exists("did_sapic_syn_inits")
+  if version < 508
+    let did_sapic_syn_inits = 1
+  endif
+  SpthyHiLink sapicLAtom		Operator
+  SpthyHiLink sapicProc		Operator
+  SpthyHiLink sapicComment		Comment
+  SpthyHiLink sapicDocComment		Comment
+  SpthyHiLink sapicLineComment		Comment
+  SpthyHiLink sapicError		Error
+  SpthyHiLink sapicDecl		        Typedef
+  SpthyHiLink sapicTransfer             Typedef
+  SpthyHiLink sapicConstr               Function
+  SpthyHiLink sapicLiteral              String
+  SpthyHiLink sapicTODO                 Todo
+  SpthyHiLink sapicLogicOp              Boolean
+"  SpthyHiLink sapicVarArg               Function
+"  SpthyHiLink sapicBraces		Function
+"  SpthyHiLink sapicBranch		Conditional
+"  SpthyHiLink sapicUserLabelRef		sapicUserLabel
+"  SpthyHiLink sapicLabel		Label
+"  SpthyHiLink sapicUserLabel		Label
+"  SpthyHiLink sapicConditional		Conditional
+"  SpthyHiLink sapicRepeat		Repeat
+"  SpthyHiLink sapicExceptions		Exception
+"  SpthyHiLink sapicAssert		Statement
+"  SpthyHiLink sapicStorageClass		StorageClass
+"  SpthyHiLink sapicMethodDecl		sapicStorageClass
+"  SpthyHiLink sapicClassDecl		sapicStorageClass
+"  SpthyHiLink sapicScopeDecl		sapicStorageClass
+"  SpthyHiLink sapicBoolean		Boolean
+"  SpthyHiLink sapicSpecial		Special
+"  SpthyHiLink sapicSpecialError		Error
+"  SpthyHiLink sapicSpecialCharError	Error
+"  SpthyHiLink sapicString		String
+"  SpthyHiLink sapicCharacter		Character
+"  SpthyHiLink sapicSpecialChar		SpecialChar
+"  SpthyHiLink sapicNumber		Number
+"  SpthyHiLink sapicStringError		Error
+"  SpthyHiLink sapicStatement		Statement
+"  SpthyHiLink sapicOperator		Operator
+"  SpthyHiLink sapicComment		Comment
+"  SpthyHiLink sapicDocComment		Comment
+"  SpthyHiLink sapicLineComment		Comment
+"  SpthyHiLink sapicConstant		Constant
+"  SpthyHiLink sapicTypedef		Typedef
+"  SpthyHiLink sapicTodo			Todo
+"  SpthyHiLink sapicAnnotation             PreProc
+"
+"  SpthyHiLink sapicCommentTitle		SpecialComment
+"  SpthyHiLink sapicDocTags		Special
+"  SpthyHiLink sapicDocParam		Function
+"  SpthyHiLink sapicDocSeeTagParam		Function
+"  SpthyHiLink sapicCommentStar		sapicComment
+"
+"  SpthyHiLink sapicType			Type
+"  SpthyHiLink sapicExternal		Include
+"
+"  SpthyHiLink htmlComment		Special
+"  SpthyHiLink htmlCommentPart		Special
+"  SpthyHiLink sapicSpaceError		Error
+endif
+
+delcommand SpthyHiLink
+
+let b:current_syntax = "sapic"
+
+if main_syntax == 'sapic'
+  unlet main_syntax
+endif
+
+let b:spell_options="contained"
+
+" vim: ts=8

--- a/syntax/spthy.vim
+++ b/syntax/spthy.vim
@@ -1,0 +1,212 @@
+" Vim syntax file
+" Language:     DH-proto-proof Security Protocol Theory Files
+" Maintainer:   Nick Moore <nicholas.moore@cs.ox.ac.uk>
+" Last Change:  2018 04 10
+" based on Claudio Fleiner's <claudio@fleiner.com> spthy syntax highlighting
+" file.
+
+" Quit when a syntax file was already loaded
+if !exists("main_syntax")
+  if version < 600
+    syntax clear
+  elseif exists("b:current_syntax")
+    finish
+  endif
+  " we define it here so that included files can test for it
+  let main_syntax='spthy'
+  syn region spthyFold start="{" end="}" transparent fold
+endif
+
+" don't use standard HiLink, it will not work with included syntax files
+if version < 508
+  command! -nargs=+ SpthyHiLink hi link <args>
+else
+  command! -nargs=+ SpthyHiLink hi def link <args>
+endif
+
+" some characters that cannot be in a spthy program (outside a string)
+" syn match spthyError "[\\@`]"
+" syn match spthyError "<<<\|\.\.\|=>\|<>\|||=\|&&=\|[^-]->\|\*\/"
+" syn match spthyOK "\.\.\."
+
+syn match spthyLAtom	        ":>"
+syn match spthyLAtom	        "--|"
+syn match spthyLAtom	        "<:"
+syn match spthyLAtom	        ">+>"
+syn match spthyLAtom	        ">->"
+syn match spthyLAtom	        "="
+syn match spthyLAtom	        "@"
+syn match spthyLAtom	        "<"
+syn match spthyLAtom	        ">"
+
+syn keyword spthyConstr         aenc sdec senc sdec sign verify hashing signing multiset
+syn match spthyConstr           "\<h("he=e-1
+syn match spthyConstr           "\<sk("he=e-1
+syn match spthyConstr           "\<pk("he=e-1
+syn match spthyConstr           "\<fr("he=e-1
+syn match spthyConstr           "\<pb("he=e-1
+syn match spthyConstr           "\<lts("he=e-1
+syn match spthyConstr           "*"
+syn match spthyConstr           "\^"
+syn match spthyConstr           "\<diffie-hellman"
+syn match spthyConstr           "\<symmetric-encryption"
+syn match spthyConstr           "\<asymmetric-encryption"
+
+syn keyword spthyDecl           axiom restriction equations functions builtins protocol property in let theory begin end subsection section text
+syn match spthyDecl             "\<lemma\>"
+syn match spthyDecl             "\<exists-trace"
+syn match spthyDecl             "\<all-traces"
+syn match spthyDecl             "\<enable"
+syn match spthyDecl             "\<rule"
+syn match spthyDecl             "\<assertions"
+syn match spthyDecl             "\<modulo"
+syn match spthyDecl             "\<default_rules"
+syn match spthyDecl             "\<anb-proto"
+syn match spthyDecl             ":"
+syn match spthyDecl             "{\*"
+syn match spthyDecl             "\*}"
+syn match spthyDecl             "\""
+syn match spthyDecl             "[a-zA-Z\-_]\@<!\d\+\."
+
+syn match spthyTransfer         "->"
+syn match spthyTransfer         "<-"
+syn match spthyDecl             "-->"
+syn match spthyDecl             "--\["
+syn match spthyDecl             "\]->"
+
+syn region spthyLiteral          start="'" end="'"
+
+syn keyword spthyAnnot          contained use_induction sources reuse hide_lemma left right
+syn region spthyAnnotLemma      matchgroup=spthyDecl start="\<lemma\>" skip="(\s\+\w\+\s*\[|\])" end=":" matchgroup=NONE contains=spthyAnnot
+
+syn match spthyLogicOp          "==>"
+syn match spthyLogicOp          "<=>"
+syn keyword spthyLogicOp        F T All Ex
+syn match spthyLogicOp          "|"
+syn match spthyLogicOp          "&"
+syn match spthyLogicOp          "\."
+
+" The following cluster contains all spthy groups except the contained ones
+syn cluster spthyTop add=spthyLAtom,spthyDecl
+
+
+" Comments
+syn keyword spthyTodo		 contained TODO FIXME XXX
+syn region  spthyComment		 start="/\*"  end="\*/" contains=spthyTodo
+syn match   spthyLineComment      "//.*" contains=spthyTodo
+
+syn cluster spthyTop add=spthyComment,spthyLineComment
+
+" Strings and constants
+" syn match   spthySpecialError     contained "\\."
+" syn match   spthySpecialCharError contained "[^']"
+" syn match   spthySpecialChar      contained "\\\([4-9]\d\|[0-3]\d\d\|[\"\\'ntbrf]\|u\+\x\{4\}\)"
+" syn region  spthyString		start=+"+ end=+"+ end=+$+ contains=spthySpecialChar,spthySpecialError,@Spell
+" " next line disabled, it can cause a crash for a long line
+" "syn match   spthyStringError	  +"\([^"\\]\|\\.\)*$+
+" syn match   spthyCharacter	 "'[^']*'" contains=spthySpecialChar,spthySpecialCharError
+" syn match   spthyCharacter	 "'\\''" contains=spthySpecialChar
+" syn match   spthyCharacter	 "'[^\\]'"
+" syn match   spthyNumber		 "\<\(0[0-7]*\|0[xX]\x\+\|\d\+\)[lL]\=\>"
+" syn match   spthyNumber		 "\(\<\d\+\.\d*\|\.\d\+\)\([eE][-+]\=\d\+\)\=[fFdD]\="
+" syn match   spthyNumber		 "\<\d\+[eE][-+]\=\d\+[fFdD]\=\>"
+" syn match   spthyNumber		 "\<\d\+\([eE][-+]\=\d\+\)\=[fFdD]\>"
+"
+" " unicode characters
+" syn match   spthySpecial "\\u\+\d\{4\}"
+"
+" syn cluster spthyTop add=spthyString,spthyCharacter,spthyNumber,spthySpecial,spthyStringError
+
+" catch errors caused by wrong parenthesis
+" syn region  spthyParenT  transparent matchgroup=spthyParen  start="("  end=")" contains=@spthyTop,spthyParenT1
+" syn region  spthyParenT1 transparent matchgroup=spthyParen1 start="(" end=")" contains=@spthyTop,spthyParenT2 contained
+" syn region  spthyParenT2 transparent matchgroup=spthyParen2 start="(" end=")" contains=@spthyTop,spthyParenT  contained
+" syn match   spthyParenError       ")"
+" " catch errors caused by wrong square parenthesis
+" syn region  spthyParenT  transparent matchgroup=spthyParen  start="\["  end="\]" contains=@spthyTop,spthyParenT1
+" syn region  spthyParenT1 transparent matchgroup=spthyParen1 start="\[" end="\]" contains=@spthyTop,spthyParenT2 contained
+" syn region  spthyParenT2 transparent matchgroup=spthyParen2 start="\[" end="\]" contains=@spthyTop,spthyParenT  contained
+" syn match   spthyParenError       "\]"
+"
+" SpthyHiLink spthyParenError       spthyError
+
+if !exists("spthy_minlines")
+  let spthy_minlines = 10
+endif
+exec "syn sync ccomment spthyComment minlines=" . spthy_minlines
+
+" The default highlighting.
+if version >= 508 || !exists("did_spthy_syn_inits")
+  if version < 508
+    let did_spthy_syn_inits = 1
+  endif
+  SpthyHiLink spthyLAtom		Operator
+  SpthyHiLink spthyComment		Comment
+  SpthyHiLink spthyDocComment		Comment
+  SpthyHiLink spthyLineComment		Comment
+  SpthyHiLink spthyError		Error
+  SpthyHiLink spthyDecl		        Typedef
+  SpthyHiLink spthyTransfer             Typedef
+  SpthyHiLink spthyConstr               Function
+  SpthyHiLink spthyAnnot                Label
+  SpthyHiLink spthyLiteral              String
+  SpthyHiLink spthyTODO                 Todo
+  SpthyHiLink spthyLogicOp              Boolean
+"  SpthyHiLink spthyVarArg               Function
+"  SpthyHiLink spthyBraces		Function
+"  SpthyHiLink spthyBranch		Conditional
+"  SpthyHiLink spthyUserLabelRef		spthyUserLabel
+"  SpthyHiLink spthyLabel		Label
+"  SpthyHiLink spthyUserLabel		Label
+"  SpthyHiLink spthyConditional		Conditional
+"  SpthyHiLink spthyRepeat		Repeat
+"  SpthyHiLink spthyExceptions		Exception
+"  SpthyHiLink spthyAssert		Statement
+"  SpthyHiLink spthyStorageClass		StorageClass
+"  SpthyHiLink spthyMethodDecl		spthyStorageClass
+"  SpthyHiLink spthyClassDecl		spthyStorageClass
+"  SpthyHiLink spthyScopeDecl		spthyStorageClass
+"  SpthyHiLink spthyBoolean		Boolean
+"  SpthyHiLink spthySpecial		Special
+"  SpthyHiLink spthySpecialError		Error
+"  SpthyHiLink spthySpecialCharError	Error
+"  SpthyHiLink spthyString		String
+"  SpthyHiLink spthyCharacter		Character
+"  SpthyHiLink spthySpecialChar		SpecialChar
+"  SpthyHiLink spthyNumber		Number
+"  SpthyHiLink spthyStringError		Error
+"  SpthyHiLink spthyStatement		Statement
+"  SpthyHiLink spthyOperator		Operator
+"  SpthyHiLink spthyComment		Comment
+"  SpthyHiLink spthyDocComment		Comment
+"  SpthyHiLink spthyLineComment		Comment
+"  SpthyHiLink spthyConstant		Constant
+"  SpthyHiLink spthyTypedef		Typedef
+"  SpthyHiLink spthyTodo			Todo
+"  SpthyHiLink spthyAnnotation             PreProc
+"
+"  SpthyHiLink spthyCommentTitle		SpecialComment
+"  SpthyHiLink spthyDocTags		Special
+"  SpthyHiLink spthyDocParam		Function
+"  SpthyHiLink spthyDocSeeTagParam		Function
+"  SpthyHiLink spthyCommentStar		spthyComment
+"
+"  SpthyHiLink spthyType			Type
+"  SpthyHiLink spthyExternal		Include
+"
+"  SpthyHiLink htmlComment		Special
+"  SpthyHiLink htmlCommentPart		Special
+"  SpthyHiLink spthySpaceError		Error
+endif
+
+delcommand SpthyHiLink
+
+let b:current_syntax = "spthy"
+
+if main_syntax == 'spthy'
+  unlet main_syntax
+endif
+
+let b:spell_options="contained"
+
+" vim: ts=8


### PR DESCRIPTION
Adds the original syntax files for Vim (from the manual). This directory layout works for Vundle (and other plugin managers for Vim) --- even when other files are added, unless the file names clash, of course.