### PR TITLE
Minor improvements to vim/emacs files

### DIFF
--- a/spthy-mode.el
+++ b/spthy-mode.el
@@ -25,16 +25,16 @@
 (add-to-list 'auto-mode-alist '("\\.spthy\\'" . spthy-mode))
 
 (defvar spthy-keywords
-  '("axiom" "lemma" "restriction" "protocol" "property" "text" "rule" "let" "in" "Fresh" "fresh" "Public" "public" "hashing" "All" "Ex" "h" "sk" "pk" "Fr" "In" "Out" "fr" "in" "out" "not" "!"))
+  '("axiom" "lemma" "restriction" "protocol" "property" "text" "rule" "let" "in" "Fresh" "fresh" "Public" "public" "All" "Ex" "h" "sk" "pk" "Fr" "In" "Out" "fr" "in" "out" "not" "!"))
 
 (defvar spthy-events
-  '("theory" "begin" "end" "subsection" "section" "pb" "lts" "diffie-hellman" "bilinear-pairing" "multiset" "symmetric-encryption" "asymmetric-encryption" "exists-trace" "all-traces" "enable" "assertions" "modulo" "default_rules" "anb-proto" "signing"))
+  '("theory" "begin" "end" "subsection" "section" "pb" "lts" "diffie-hellman" "bilinear-pairing" "multiset" "hashing" "symmetric-encryption" "asymmetric-encryption" "exists-trace" "all-traces" "enable" "assertions" "modulo" "default_rules" "anb-proto" "signing"))
 
 (defvar spthy-operators
   '("&" "|" "==>" "=" "<=>" "-->" "^" "[" "]->" "-->" "]" "--["))
 
 (defvar spthy-warnings
-  '("@" "functions" "builtins" "equations" "!")) ; we may want to add ! in operators instead
+  '("@" "functions" "builtins" "equations" "heuristic" "!")) ; we may want to add ! in operators instead
 
 (defvar spthy-quiet
   '("~" "$"))

--- a/syntax/sapic.vim
+++ b/syntax/sapic.vim
@@ -39,7 +39,7 @@ syn match sapicLAtom	        "@"
 syn match sapicLAtom	        "<"
 
 
-syn keyword sapicConstr         aenc sdec senc sdec sign verify hashing signing
+syn keyword sapicConstr         aenc adec senc sdec sign verify hashing signing
 syn match sapicConstr           "\<h("he=e-1
 syn match sapicConstr           "\<sk("he=e-1
 syn match sapicConstr           "\<pk("he=e-1
@@ -53,7 +53,7 @@ syn match sapicConstr           "\<symmetric-encryption"
 syn match sapicConstr           "\<asymmetric-encryption"
 syn match sapicConstr           "\<multiset"
 
-syn keyword sapicDecl           axiom lemma equations functions builtins protocol property in let theory begin end subsection section text predicates options
+syn keyword sapicDecl           axiom lemma equations functions builtins heuristic protocol property in let theory begin end subsection section text predicates options
 syn match sapicDecl             "\<exists-trace"
 syn match sapicDecl             "\<all-traces"
 syn match sapicDecl             "\<enable"

--- a/syntax/spthy.vim
+++ b/syntax/spthy.vim
@@ -39,7 +39,7 @@ syn match spthyLAtom	        "@"
 syn match spthyLAtom	        "<"
 syn match spthyLAtom	        ">"
 
-syn keyword spthyConstr         aenc sdec senc sdec sign verify hashing signing multiset
+syn keyword spthyConstr         aenc adec senc sdec sign verify hashing signing multiset
 syn match spthyConstr           "\<h("he=e-1
 syn match spthyConstr           "\<sk("he=e-1
 syn match spthyConstr           "\<pk("he=e-1
@@ -52,7 +52,7 @@ syn match spthyConstr           "\<diffie-hellman"
 syn match spthyConstr           "\<symmetric-encryption"
 syn match spthyConstr           "\<asymmetric-encryption"
 
-syn keyword spthyDecl           axiom restriction equations functions builtins protocol property in let theory begin end subsection section text
+syn keyword spthyDecl           axiom restriction equations functions builtins heuristic protocol property in let theory begin end subsection section text
 syn match spthyDecl             "\<lemma\>"
 syn match spthyDecl             "\<exists-trace"
 syn match spthyDecl             "\<all-traces"


### PR DESCRIPTION
- Fixes a typo that caused `adec` functions not to be highlighted (vim)
- Properly highlights the `heuristic` keyword, which was added in PR #303 (vim / emacs)
- Makes `hashing` keyword consistent with other built-in theories (emacs)